### PR TITLE
allow defining arbitrary structs and arr of structs in model

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -118,7 +118,9 @@ func (prop *Property) GenerateGoStructs() (string, error) {
 	}
 
 	if !found {
-		return "", errors.New("Unknown Property")
+		if _, ok := validObjects[prop.Type]; !ok {
+			return "", errors.New("Unknown Property")
+		}
 	}
 	byt, err := generators.RunTemplate("propstruct", prop)
 	return string(byt), err

--- a/generators/generators.go
+++ b/generators/generators.go
@@ -14,7 +14,8 @@ var funcMap = template.FuncMap{
 	"initialLow":    texthelpers.InitialLow,
 	"depunct":       texthelpers.Depunct,
 	"capFirst":      texthelpers.CapFirst,
-	"translateType": texthelpers.TranslatePropertyType,
+	"translateCfgType": texthelpers.TranslateCfgPropertyType,
+	"translateOperType": texthelpers.TranslateOperPropertyType,
 }
 
 func ParseTemplates() error {

--- a/generators/templates.go
+++ b/generators/templates.go
@@ -457,7 +457,7 @@ type {{ initialCap .Name }}Inspect struct {
 }
   `,
 	"propstruct": `
-{{ initialCap .Name }}{{ if eq .Type "array" }} []{{ translateType .Items }} ` + "`" + `json:"{{ .Name }},omitempty"` + "`" + ` {{ else }} {{ translateType .Type }} ` + "`" + `json:"{{ .Name }},omitempty"` + "`" + ` // {{.Title}} {{ end }}
+{{ initialCap .Name }} {{ if eq .Type "array" }} []{{ if .CfgObject }}{{ translateCfgType .Items }}{{ else }}{{ translateOperType .Items }}{{ end }} ` + "`" + `json:"{{ .Name }},omitempty"` + "`" + `{{ else }} {{ if .CfgObject }}{{ translateCfgType .Type }}{{ else }}{{ translateOperType .Type }}{{ end}} ` + "`" + `json:"{{ .Name }},omitempty"` + "`" + ` // {{.Title}} {{ end }}
   `,
 	"pyclientHdr": `
 # {{.Name}} REST client

--- a/generators/templates/propstruct.tmpl
+++ b/generators/templates/propstruct.tmpl
@@ -1,1 +1,1 @@
-{{ initialCap .Name }}{{ if eq .Type "array" }} []{{ translateType .Items }} `json:"{{ .Name }},omitempty"` {{ else }} {{ translateType .Type }} `json:"{{ .Name }},omitempty"` // {{.Title}} {{ end }}
+{{ initialCap .Name }} {{ if eq .Type "array" }} []{{ if .CfgObject }}{{ translateCfgType .Items }}{{ else }}{{ translateOperType .Items }}{{ end }} `json:"{{ .Name }},omitempty"`{{ else }} {{ if .CfgObject }}{{ translateCfgType .Type }}{{ else }}{{ translateOperType .Type }}{{ end}} `json:"{{ .Name }},omitempty"` // {{.Title}} {{ end }}

--- a/jsgen.go
+++ b/jsgen.go
@@ -27,7 +27,8 @@ var funcMap = template.FuncMap{
 	"initialLow":    texthelpers.InitialLow,
 	"depunct":       texthelpers.Depunct,
 	"capFirst":      texthelpers.CapFirst,
-	"translateType": texthelpers.TranslatePropertyType,
+	"translateCfgType": texthelpers.TranslateCfgPropertyType,
+	"translateOperType": texthelpers.TranslateOperPropertyType,
 }
 
 func (s *Schema) GenerateJs() ([]byte, error) {

--- a/schema.go
+++ b/schema.go
@@ -48,6 +48,7 @@ type Property struct {
 	Default     string  `json:"default,omitempty"`
 	Format      string  `json:"format,omitempty"`
 	ShowSummary bool    `json:"showSummary,omitempty"`
+	CfgObject   bool    `json:"showSummary,omitempty"`
 }
 
 type LinkSet struct {

--- a/testdata/one/input.json
+++ b/testdata/one/input.json
@@ -140,6 +140,41 @@
 					"type": "string"
 				}
 			}
+		},
+		{
+			"name": "epList",
+			"version": "v1",
+			"type": "object",
+			"key": ["name"],
+			"operProperties": {
+				"name": {
+			  		"type": "string"
+				},
+				"subnet": {
+					"type": "string"
+				},
+				"eps" : {
+					"type": "array",
+					"items": "endpoint"
+				}
+			}
+		},
+		{
+			"name": "netWithEp",
+			"version": "v1",
+			"type": "object",
+			"key": ["name"],
+			"operProperties": {
+				"name": {
+			  		"type": "string"
+				},
+				"subnet": {
+					"type": "string"
+				},
+				"ep" : {
+					"type": "endpoint"
+				}
+			}
 		}
 	]
 }

--- a/texthelpers/utils.go
+++ b/texthelpers/utils.go
@@ -64,7 +64,7 @@ func CapFirst(ident string) string {
 	return string(unicode.ToUpper(r)) + ident[n:]
 }
 
-func TranslatePropertyType(propType string) string {
+func TranslateCfgPropertyType(propType string) string {
 	var goStr string
 	switch propType {
 	case "string":
@@ -76,7 +76,25 @@ func TranslatePropertyType(propType string) string {
 	case "bool":
 		return propType
 	default:
-		return ""
+		return InitialCap(propType)+"Cfg"
+	}
+
+	return goStr
+}
+
+func TranslateOperPropertyType(propType string) string {
+	var goStr string
+	switch propType {
+	case "string":
+		fallthrough
+	case "number":
+		fallthrough
+	case "int":
+		fallthrough
+	case "bool":
+		return propType
+	default:
+		return InitialCap(propType)+"Oper"
 	}
 
 	return goStr


### PR DESCRIPTION
Two additions to object model:
- Cfg/Oper Properties can include a pre-defined object inside another object
- Cfg/Oper Properties can include an array of a pre-defined struct/object inside another object

For example:

```
    {
      "name": "endpoint",
      "version": "v1",
      "type": "object",
      "key": ["uuid"],
      "operProperties": {
        "uuid": {
            "type": "string"
        },  
        "labels": {
          "type": "string"
        }   
      }   
    },  
    {   
      "name": "epList",
      "version": "v1",
      "type": "object",
      "key": ["name"],
      "operProperties": {
        "name": {
            "type": "string"
        },  
        "subnet": {
          "type": "string"
        },  
        "eps" : { 
          "type": "array",
          "items": "endpoint"
        }
      }
    },
    {
      "name": "netWithEp",
      "version": "v1",
      "type": "object",
      "key": ["name"],
      "operProperties": {
        "name": {
            "type": "string"
        },
        "subnet": {
          "type": "string"
        },
        "ep" : {
          "type": "endpoint"
        }
      }
    }
```
